### PR TITLE
Modal countdown disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ add_filter('dawp_modal_timeout', function($timeout) {
     return 15000; // New timeout in milliseconds
 });
 ```
+
+### Disable Modal Timer
+```php
+add_filter('dawp_disable_modal_timer', '__return_true');
+```
+
 ### Adjust Action Log Pagination
 ```php
 add_filter('dawp_log_pagination_count', function($count) {
@@ -51,8 +57,6 @@ function my_custom_critical_plugins($critical_plugins) {
 }
 add_filter('da_mission_critical_plugins', 'my_custom_critical_plugins');
 ```
-
-
 ## Screenshots
 
 #### Mission Critical Plugin

--- a/assets/js/dawp-modal.js
+++ b/assets/js/dawp-modal.js
@@ -50,17 +50,21 @@ document.addEventListener('DOMContentLoaded', function() {
             cancelAction.style.display = 'none';
             this.style.display = 'none';
 
-            var countdown = modalTimeout / 1000;
-            countdownMessage.textContent = 'Plugin ' + action + ' will complete in ' + countdown + ' seconds';
-            countdownMessage.style.display = 'block';
-            cancelCountdown.style.display = 'block';
-
-            countdownInterval = setInterval(function() {
-                countdown--;
+            if (dawpModalData.timerDisabled) {
+                // Timer is disabled, directly proceed with action
+                window.location.href = actionUrl;
+            } else {
+                var countdown = modalTimeout / 1000;
                 countdownMessage.textContent = 'Plugin ' + action + ' will complete in ' + countdown + ' seconds';
-                if (countdown <= 0) {
-                    clearInterval(countdownInterval);
-                    // AJAX request
+                countdownMessage.style.display = 'block';
+                cancelCountdown.style.display = 'block';
+
+                countdownInterval = setInterval(function() {
+                    countdown--;
+                    countdownMessage.textContent = 'Plugin ' + action + ' will complete in ' + countdown + ' seconds';
+                    if (countdown <= 0) {
+                        clearInterval(countdownInterval);
+                        // AJAX request
                         fetch(dawpModalData.ajax_url, {
                             method: 'POST',
                             headers: {
@@ -80,6 +84,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         });
                     }
                 }, 1000);
+            }
         });
 
         // If the user chooses to cancel the countdown

--- a/includes/class-plugin-action-safety.php
+++ b/includes/class-plugin-action-safety.php
@@ -32,13 +32,15 @@ class PluginActionSafety
         // Enqueue modal.js only on the plugins.php page
         if ($pagenow == 'plugins.php' && empty($_GET['page'])) {
             $modal_timeout = apply_filters('dawp_modal_timeout', 10000); // Default is 10000 milliseconds
+            $modal_timer_disabled = apply_filters('dawp_disable_modal_timer', false); // Default is false
 
             wp_enqueue_script('dawp-modal', ACTION_SAFETY_FEATURE_URL . 'assets/js/dawp-modal.js', null, ACTION_SAFETY_FEATURE_VERSION, true);
 
             wp_localize_script('dawp-modal', 'dawpModalData', array(
                 'ajax_url' => admin_url('admin-ajax.php'),
                 'nonce' => wp_create_nonce('wp_nonce_action'),
-                'timeout' => $modal_timeout
+                'timeout' => $modal_timeout,
+                'timerDisabled' => $modal_timer_disabled
             ));
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,12 @@ add_filter('dawp_modal_timeout', function($timeout) {
     return 15000; // New timeout in milliseconds
 });
 ```
+
+### Disable Modal Timer
+```php
+add_filter('dawp_disable_modal_timer', '__return_true');
+```
+
 ### Adjust Action Log Pagination
 ```php
 add_filter('dawp_log_pagination_count', function($count) {

--- a/wp-action-safety-feature.php
+++ b/wp-action-safety-feature.php
@@ -5,7 +5,7 @@
  * Description: Enhance plugin management safety on WordPress sites with the Plugin Actions Safety Feature. This plugin introduces a warning modal for critical plugin activations/deactivations, logs these actions for accountability, and supports CSV exports of the log. It also includes a purging feature for log management and protects mission-critical plugins from accidental deactivation, including bulk action prevention. Optionally extendable for custom purge timelines and modal timeouts.
  * Author: Danny Albeck
  * Author URI: https://github.com/dalbeck/
- * Version: 1.2.1
+ * Version: 1.2.2
  * Text Domain: actions-safety-feature
  * Domain Path: /languages
  * License: GNU General Public License v3.0
@@ -32,7 +32,7 @@ if (!defined('WPINC')) {
 }
 
 // Define plugin version constant.
-define('ACTION_SAFETY_FEATURE_VERSION', '1.2.1');
+define('ACTION_SAFETY_FEATURE_VERSION', '1.2.2');
 
 // Define the base URL for the plugin.
 define('ACTION_SAFETY_FEATURE_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
- added new filter dawp_disable_modal_timer to extend functionality and allow for disabling the additional timer if you prefer to not have any.